### PR TITLE
Correct link to RL AI repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The graph indicates that the AI performs relatively weak in early stage of the g
 
 Without the help of human made features and heuristics like what is used in https://github.com/nneonneo/2048-ai , the network can still reaches at least 75% success rate for the same network architecture. 
 
-A much smaller model trained without using any human made features and heuristics reaches 47% of success rate, can be found at http://github.ocm/tjwei/rl/
+A much smaller model trained without using any human made features and heuristics reaches 47% of success rate, can be found at http://github.com/tjwei/rl/
 
 
 The `animationDelay` is set to 10. You can make it run faster or slower with a different delay time. 


### PR DESCRIPTION
The link to the tjwei/rl has the c and o in ".com" transposed. This fixes that. 

As an aside,  thanks for the detailed readme  with links!